### PR TITLE
Simple and naive bootstrap framework detection, fixes #2

### DIFF
--- a/favelets/analyzer/code2.js
+++ b/favelets/analyzer/code2.js
@@ -1,4 +1,4 @@
-﻿(function() {
+(function() {
 
 
 
@@ -522,6 +522,8 @@
                 wnd.Drupal && ret.push("Drupal.js - they have no version ?");
                 wnd.vaadin && ret.push("vaadin - they have no version ?");
                 wnd.janrain && ret.push("janrain - they have no version ?");
+                wnd.jQuery && wnd.jQuery.fn && wnd.jQuery.fn.modal && ret.push("Bootstrap - " + //
+                (wnd.jQuery.fn.modal.Constructor ? (wnd.jQuery.fn.modal.Constructor.VERSION || "2.x.x - 3.1.1") : "1.x.x"));
 
                 var g = that.globals();
                 var r = {};


### PR DESCRIPTION
I have added naive detection as it's not always possible detect it in a simple way. Bootstrap since v 3.2.0 exposes VERSION attribute, which can be used, however before, there was none. For this case a different approach was applied.
